### PR TITLE
Fix executable compiling inside container

### DIFF
--- a/cpp.Dockerfile
+++ b/cpp.Dockerfile
@@ -6,4 +6,4 @@ WORKDIR /function
 
 COPY . .
 
-RUN make
+RUN make clean && make

--- a/cuda.Dockerfile
+++ b/cuda.Dockerfile
@@ -1,8 +1,5 @@
 FROM nvidia/cuda:9.1-devel as base
 
-LABEL builder-language="cuda"
-LABEL version="1.0.0"
-
 RUN apt-get install -y make \
   && rm -rf /var/lib/apt/lists/*
 

--- a/cuda.Dockerfile
+++ b/cuda.Dockerfile
@@ -1,5 +1,8 @@
 FROM nvidia/cuda:9.1-devel as base
 
+LABEL builder-language="cuda"
+LABEL version="1.0.0"
+
 RUN apt-get install -y make \
   && rm -rf /var/lib/apt/lists/*
 
@@ -7,4 +10,4 @@ WORKDIR /function
 
 COPY . .
 
-RUN make
+RUN make clean && make


### PR DESCRIPTION
When running `COPY . .` the executables generated by running `make` could be copied too. Running make inside the container now will not recompile the files, but the environment inside the container is somewhat different from the host. This could lead to problems, such as ENOENT when asking to execute the file, even if the file exists.

Now before `make` inside the container a `make clean` is run. _The user should guarantee that all compiled files are deleted when running make._